### PR TITLE
Tests for v16 ibc rate limiting

### DIFF
--- a/interchaintests/fresh/const.go
+++ b/interchaintests/fresh/const.go
@@ -6,8 +6,9 @@ const (
 	NUM_VALIDATORS  = 3
 	VALIDATOR_FUNDS = 11_000_000_000
 	// This moniker is hardcoded into the chain's genesis process.
-	VALIDATOR_MONIKER = "validator"
-	RELAYER_PATH_NAME = "ibc-path"
+	VALIDATOR_MONIKER  = "validator"
+	RELAYER_PATH_NAME  = "ibc-path"
+	GOV_DEPOSIT_AMOUNT = "5000000" + DENOM
 )
 
 func getValidatorStake() [NUM_VALIDATORS]int64 {

--- a/interchaintests/fresh/ibc_rate_limit.go
+++ b/interchaintests/fresh/ibc_rate_limit.go
@@ -1,0 +1,141 @@
+package fresh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	"github.com/strangelove-ventures/interchaintest/v7"
+	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v7/ibc"
+	"github.com/stretchr/testify/require"
+)
+
+func IBCTransferRateLimitedTest(
+	ctx context.Context,
+	t *testing.T,
+	chainA *cosmos.CosmosChain,
+	chainB *cosmos.CosmosChain,
+	channel *ibc.ChannelOutput,
+) {
+	addRateLimit(ctx, t, chainA, channel.ChannelID)
+	sendRateLimitedTx(ctx, t, chainA, chainB, channel, true)
+
+	updateRateLimit(ctx, t, chainA, channel.ChannelID)
+	sendRateLimitedTx(ctx, t, chainA, chainB, channel, false)
+}
+
+func sendRateLimitedTx(
+	ctx context.Context,
+	t *testing.T,
+	chainA *cosmos.CosmosChain,
+	chainB *cosmos.CosmosChain,
+	channel *ibc.ChannelOutput,
+	shouldPass bool,
+) {
+	wallets, err := GetValidatorWallets(ctx, chainB)
+	require.NoError(t, err)
+	walletB := wallets[0]
+
+	supply, err := QuerySupply(ctx, chainA, DENOM)
+	require.NoError(t, err)
+
+	threshold := supply.Amount.Quo(sdkmath.NewInt(100))
+	amount := threshold.Add(sdkmath.NewInt(10))
+
+	// Use the faucet to send because it has a ton of tokens (~100T); other accounts may not have 1% of the supply
+	_, err = chainA.SendIBCTransfer(ctx, channel.ChannelID, interchaintest.FaucetAccountKeyName, ibc.WalletAmount{
+		Address: walletB.Address,
+		Amount:  amount,
+		Denom:   DENOM,
+	}, ibc.TransferOptions{})
+	if shouldPass {
+		require.NoError(t, err)
+	} else {
+		require.Error(t, err)
+	}
+}
+
+func updateRateLimit(ctx context.Context, t *testing.T, chain *cosmos.CosmosChain, channelID string) {
+	govAuthority, err := chain.GetModuleAddress(ctx, "gov")
+	require.NoError(t, err)
+	msg := map[string]interface{}{
+		"@type":            "/ratelimit.v1.MsgUpdateRateLimit",
+		"authority":        govAuthority,
+		"denom":            DENOM,
+		"channel_id":       channelID,
+		"max_percent_send": sdkmath.NewInt(1).String(),
+		"max_percent_recv": sdkmath.NewInt(1).String(),
+		"duration_hours":   "48",
+	}
+	marshaled, err := json.Marshal(msg)
+	require.NoError(t, err)
+	txhash, err := chain.GetNode().SubmitProposal(ctx, VALIDATOR_MONIKER,
+		cosmos.TxProposalv1{
+			Title:    "Update rate limits on channel " + channelID,
+			Deposit:  GOV_DEPOSIT_AMOUNT,
+			Messages: []json.RawMessage{json.RawMessage(marshaled)},
+			Summary:  "Update rate limits on channel " + channelID,
+			Metadata: "ipfs://CID",
+		})
+	require.NoError(t, err)
+	propID, err := getProposalID(ctx, chain, txhash)
+	require.NoError(t, err)
+	PassProposal(ctx, t, chain, propID)
+}
+
+func addRateLimit(ctx context.Context, t *testing.T, chain *cosmos.CosmosChain, channelID string) {
+	govAuthority, err := chain.GetModuleAddress(ctx, "gov")
+	require.NoError(t, err)
+	msg := map[string]interface{}{
+		"@type":            "/ratelimit.v1.MsgAddRateLimit",
+		"authority":        govAuthority,
+		"denom":            DENOM,
+		"channel_id":       channelID,
+		"max_percent_send": sdkmath.NewInt(2).String(),
+		"max_percent_recv": sdkmath.NewInt(1).String(),
+		"duration_hours":   "24",
+	}
+	marshaled, err := json.Marshal(msg)
+	require.NoError(t, err)
+	txhash, err := chain.GetNode().SubmitProposal(ctx, VALIDATOR_MONIKER,
+		cosmos.TxProposalv1{
+			Title:    "Add rate limits on channel " + channelID,
+			Deposit:  GOV_DEPOSIT_AMOUNT,
+			Messages: []json.RawMessage{json.RawMessage(marshaled)},
+			Summary:  "Add rate limits on channel " + channelID,
+			Metadata: "ipfs://CID",
+		})
+	require.NoError(t, err)
+	propID, err := getProposalID(ctx, chain, txhash)
+	require.NoError(t, err)
+	PassProposal(ctx, t, chain, propID)
+}
+
+func getProposalID(ctx context.Context, chain *cosmos.CosmosChain, txhash string) (string, error) {
+	// we need to do this because the rate limit proposals aren't in the sdk yet,
+	// so there'll be an error if we go through chain.SubmitProposal and expect it to parse the proposal ID
+	stdout, _, err := chain.GetNode().ExecQuery(ctx, "tx", txhash)
+	if err != nil {
+		return "", err
+	}
+	result := struct {
+		Events []abcitypes.Event `json:"events"`
+	}{}
+	if err := json.Unmarshal(stdout, &result); err != nil {
+		return "", err
+	}
+	for _, event := range result.Events {
+		if event.Type == "submit_proposal" {
+			for _, attr := range event.Attributes {
+				if string(attr.Key) == "proposal_id" {
+					return string(attr.Value), nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("proposal ID not found in tx %s", txhash)
+}

--- a/interchaintests/fresh/queries.go
+++ b/interchaintests/fresh/queries.go
@@ -1,0 +1,29 @@
+package fresh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
+)
+
+func QuerySupply(ctx context.Context, chain *cosmos.CosmosChain, denom string) (sdk.Coin, error) {
+	stdout, _, err := chain.GetNode().ExecQuery(ctx, "bank", "total")
+	if err != nil {
+		return sdk.Coin{}, err
+	}
+	result := struct {
+		Supply []sdk.Coin `json:"supply"`
+	}{}
+	if err := json.Unmarshal(stdout, &result); err != nil {
+		return sdk.Coin{}, err
+	}
+	for _, supply := range result.Supply {
+		if supply.Denom == denom {
+			return supply, nil
+		}
+	}
+	return sdk.Coin{}, fmt.Errorf("denom %s not found in supply", denom)
+}

--- a/interchaintests/fresh/v16_ibc_rate_limiting_test.go
+++ b/interchaintests/fresh/v16_ibc_rate_limiting_test.go
@@ -1,0 +1,21 @@
+package fresh_test
+
+import (
+	"testing"
+
+	"github.com/hyphacoop/cosmos-release-testing/interchaintests/fresh"
+	"github.com/stretchr/testify/require"
+)
+
+func TestV16UpgradeIBCRateLimiting(t *testing.T) {
+	ctx, err := fresh.NewTestContext(t)
+	require.NoError(t, err)
+
+	chainA, chainB, relayer := fresh.CreateLinkedChains(ctx, t, fresh.GetConfig(ctx).StartVersion)
+	channel, err := fresh.GetTransferChannel(ctx, chainA, relayer)
+	require.NoError(t, err)
+
+	fresh.UpgradeChain(ctx, t, chainA, fresh.VALIDATOR_MONIKER, fresh.GetConfig(ctx).TargetVersion, fresh.GetConfig(ctx).UpgradeVersion)
+
+	fresh.IBCTransferRateLimitedTest(ctx, t, chainA, chainB, channel)
+}


### PR DESCRIPTION
The test launches a chain, upgrades it, and then tries to do rate limiting proposals and transactions. It sets a rate limit, sends a transaction under the limit to make sure it succeeds, then lowers the limit and sends the same transaction again, expecting to now fail.