### PR TITLE
Add ICS tests to the interchaintest suite.

### DIFF
--- a/.github/workflows/upgrade-gaia-v16-fresh-interchain.yml
+++ b/.github/workflows/upgrade-gaia-v16-fresh-interchain.yml
@@ -99,6 +99,7 @@ jobs:
           TEST_UPGRADE_VERSION: ${{ matrix.upgrade_version }}
           TEST_TARGET_VERSION: ${{ env.TARGET_VERSION }}
           TEST_DOCKER_REPOSITORY: "gaia"
+          CONTAINER_LOG_TAIL: "250"
         run: |
           cd interchaintests
           go test -v -timeout 60m -run="^${{ matrix.test_name }}$" ./fresh/...

--- a/interchaintests/configuredChains.yaml
+++ b/interchaintests/configuredChains.yaml
@@ -25,3 +25,31 @@ stride:
     - repository: ghcr.io/strangelove-ventures/heighliner/stride
       uid-gid: 1025:1025
   no-host-mount: false
+
+neutron:
+  name: neutron
+  type: cosmos
+  bin: neutrond
+  bech32-prefix: neutron
+  denom: untrn
+  gas-prices: 0.01untrn
+  gas-adjustment: 1.3
+  trusting-period: "336h"
+  images:
+    - repository: ghcr.io/strangelove-ventures/heighliner/neutron
+      uid-gid: 1025:1025
+  no-host-mount: false
+
+ics-consumer:
+  name: ics-consumer
+  type: cosmos
+  bin: interchain-security-cd
+  bech32-prefix: cosmos
+  denom: stake
+  gas-prices: 0.0stake
+  gas-adjustment: 2.0
+  trusting-period: 96h
+  images:
+    - repository: ghcr.io/strangelove-ventures/heighliner/ics
+      uid-gid: 1025:1025
+  no-host-mount: false

--- a/interchaintests/fresh/baseline1_test.go
+++ b/interchaintests/fresh/baseline1_test.go
@@ -12,7 +12,7 @@ func TestBaseline1Upgrade(t *testing.T) {
 	ctx, err := fresh.NewTestContext(t)
 	require.NoError(t, err)
 
-	chain := fresh.CreateChain(ctx, t, fresh.GetConfig(ctx).StartVersion)
+	chain, _ := fresh.CreateChain(ctx, t, fresh.GetConfig(ctx).StartVersion, false)
 
 	fresh.TransactionsTest(ctx, t, chain)
 

--- a/interchaintests/fresh/baseline_consumer_chains_test.go
+++ b/interchaintests/fresh/baseline_consumer_chains_test.go
@@ -1,0 +1,74 @@
+package fresh_test
+
+import (
+	"testing"
+
+	"github.com/hyphacoop/cosmos-release-testing/interchaintests/fresh"
+	"github.com/stretchr/testify/require"
+)
+
+func runConsumerChainTest(t *testing.T, otherChain, otherChainVersion string, shouldCopyProviderKey []bool) {
+	ctx, err := fresh.NewTestContext(t)
+	require.NoError(t, err)
+
+	provider, relayer := fresh.CreateChain(ctx, t, fresh.GetConfig(ctx).StartVersion, true)
+	consumer := fresh.AddConsumerChain(ctx, t, provider, relayer, otherChain, otherChainVersion, fresh.CONSUMER_DENOM, shouldCopyProviderKey)
+
+	fresh.CCVKeyAssignmentTest(ctx, t, provider, consumer, relayer)
+	fresh.IBCTest(ctx, t, provider, consumer, relayer)
+
+	fresh.UpgradeChain(ctx, t, provider, fresh.VALIDATOR_MONIKER, fresh.GetConfig(ctx).TargetVersion, fresh.GetConfig(ctx).UpgradeVersion)
+
+	require.NoError(t, relayer.StopRelayer(ctx, fresh.GetRelayerExecReporter(ctx)))
+	require.NoError(t, relayer.StartRelayer(ctx, fresh.GetRelayerExecReporter(ctx)))
+	fresh.CCVKeyAssignmentTest(ctx, t, provider, consumer, relayer)
+	fresh.IBCTest(ctx, t, provider, consumer, relayer)
+
+	consumer2 := fresh.AddConsumerChain(ctx, t, provider, relayer, otherChain, otherChainVersion, fresh.CONSUMER_DENOM, shouldCopyProviderKey)
+	fresh.CCVKeyAssignmentTest(ctx, t, provider, consumer2, relayer)
+	fresh.IBCTest(ctx, t, provider, consumer2, relayer)
+	fresh.ValidatorJailedTest(ctx, t, provider, consumer2, relayer)
+}
+
+func TestConsumerChainLaunchesAfterV16UpgradeICS40(t *testing.T) {
+	runConsumerChainTest(t, "ics-consumer", "v4.0.0", []bool{true, true, true})
+}
+
+func TestConsumerChainLaunchesAfterV16UpgradeICS33AllKeysCopied(t *testing.T) {
+	runConsumerChainTest(t, "ics-consumer", "v3.3.0", []bool{true, true, true})
+}
+
+func TestConsumerChainLaunchesAfterV16UpgradeICS33SomeKeysCopied(t *testing.T) {
+	runConsumerChainTest(t, "ics-consumer", "v3.3.0", []bool{false, true, true})
+}
+
+func TestConsumerChainLaunchesAfterV16UpgradeICS33NoKeysCopied(t *testing.T) {
+	runConsumerChainTest(t, "ics-consumer", "v3.3.0", []bool{false, false, false})
+}
+
+func TestMainnetConsumerChainsWithV16Upgrade(t *testing.T) {
+	t.Skip("This test is failing because neutron isn't launching")
+	ctx, err := fresh.NewTestContext(t)
+	require.NoError(t, err)
+	const neutronVersion = "v3.0.1"
+	const strideVersion = "v20.0.0"
+
+	provider, relayer := fresh.CreateChain(ctx, t, fresh.GetConfig(ctx).StartVersion, true)
+	stride := fresh.AddConsumerChain(ctx, t, provider, relayer, "stride", strideVersion, fresh.STRIDE_DENOM, []bool{true, true, true})
+	neutron := fresh.AddConsumerChain(ctx, t, provider, relayer, "neutron", neutronVersion, fresh.NEUTRON_DENOM, []bool{true, true, true})
+
+	fresh.CCVKeyAssignmentTest(ctx, t, provider, neutron, relayer)
+	fresh.IBCTest(ctx, t, provider, neutron, relayer)
+	fresh.CCVKeyAssignmentTest(ctx, t, provider, stride, relayer)
+	fresh.IBCTest(ctx, t, provider, stride, relayer)
+
+	fresh.UpgradeChain(ctx, t, provider, fresh.VALIDATOR_MONIKER, fresh.GetConfig(ctx).TargetVersion, fresh.GetConfig(ctx).UpgradeVersion)
+
+	require.NoError(t, relayer.StopRelayer(ctx, fresh.GetRelayerExecReporter(ctx)))
+	require.NoError(t, relayer.StartRelayer(ctx, fresh.GetRelayerExecReporter(ctx)))
+
+	fresh.CCVKeyAssignmentTest(ctx, t, provider, neutron, relayer)
+	fresh.IBCTest(ctx, t, provider, neutron, relayer)
+	fresh.CCVKeyAssignmentTest(ctx, t, provider, stride, relayer)
+	fresh.IBCTest(ctx, t, provider, stride, relayer)
+}

--- a/interchaintests/fresh/const.go
+++ b/interchaintests/fresh/const.go
@@ -1,16 +1,41 @@
 package fresh
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
+)
+
 const (
-	UPGRADE_DELTA   = int64(10)
-	DENOM           = "uatom"
-	NUM_VALIDATORS  = 3
-	VALIDATOR_FUNDS = 11_000_000_000
+	UPGRADE_DELTA        = int64(10)
+	DENOM                = "uatom"
+	NUM_VALIDATORS       = 3
+	VALIDATOR_FUNDS      = 11_000_000_000
+	VALIDATOR_STAKE_STEP = 1_000_000
 	// This moniker is hardcoded into the chain's genesis process.
-	VALIDATOR_MONIKER  = "validator"
-	RELAYER_PATH_NAME  = "ibc-path"
-	GOV_DEPOSIT_AMOUNT = "5000000" + DENOM
+	VALIDATOR_MONIKER        = "validator"
+	GOV_DEPOSIT_AMOUNT       = "5000000" + DENOM
+	CONSUMER_DENOM           = "ucon"
+	STRIDE_DENOM             = "ustrd"
+	NEUTRON_DENOM            = "untrn"
+	TRANSFER_PORT_ID         = "transfer"
+	PROVIDER_PORT_ID         = "provider"
+	CONSUMER_PORT_ID         = "consumer"
+	COMMIT_TIMEOUT           = 10 * time.Second
+	SLASHING_WINDOW_PROVIDER = 10
+	SLASHING_WINDOW_CONSUMER = 20
+	DOWNTIME_JAIL_DURATION   = 10 * time.Second
 )
 
 func getValidatorStake() [NUM_VALIDATORS]int64 {
 	return [NUM_VALIDATORS]int64{80_000_000, 12_000_000, 8_000_000}
+}
+
+func RelayerTransferPathFor(chainA, chainB *cosmos.CosmosChain) string {
+	return fmt.Sprintf("tx-%s-%s", chainA.Config().ChainID, chainB.Config().ChainID)
+}
+
+func RelayerICSPathFor(chainA, chainB *cosmos.CosmosChain) string {
+	return fmt.Sprintf("ics-%s-%s", chainA.Config().ChainID, chainB.Config().ChainID)
 }

--- a/interchaintests/fresh/context.go
+++ b/interchaintests/fresh/context.go
@@ -2,12 +2,17 @@ package fresh
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"testing"
+	"time"
 
+	"github.com/docker/docker/client"
 	"github.com/kelseyhightower/envconfig"
+	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/testreporter"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -20,11 +25,27 @@ type loggerKey struct{}
 
 type configKey struct{}
 
+type dockerKey struct{}
+
 type Config struct {
 	StartVersion     string `envconfig:"START_VERSION" default:"v15.1.0"`
 	UpgradeVersion   string `envconfig:"UPGRADE_VERSION" default:"main"`
 	TargetVersion    string `envconfig:"TARGET_VERSION" default:"v16"`
 	DockerRepository string `envconfig:"DOCKER_REPOSITORY" default:"gaia"`
+}
+
+type dockerContext struct {
+	NetworkID string
+	Client    *client.Client
+}
+
+func WithDockerContext(ctx context.Context, d *dockerContext) context.Context {
+	return context.WithValue(ctx, dockerKey{}, d)
+}
+
+func GetDockerContext(ctx context.Context) (*client.Client, string) {
+	d, _ := ctx.Value(dockerKey{}).(*dockerContext)
+	return d.Client, d.NetworkID
 }
 
 func WithTestReporter(ctx context.Context, r *testreporter.Reporter) context.Context {
@@ -71,33 +92,40 @@ func setEnvironment() error {
 	if err := os.Setenv("IBCTEST_CONFIGURED_CHAINS", path.Join(cwd, "..", "configuredChains.yaml")); err != nil {
 		return err
 	}
-	if err := os.Setenv("CONTAINER_LOG_TAIL", "250"); err != nil {
-		return err
-	}
 	return nil
 }
 
 func NewTestContext(t *testing.T) (context.Context, error) {
 	ctx := context.Background()
-	logger := zaptest.NewLogger(t)
-	ctx = WithLogger(ctx, logger)
-
-	testReporter := testreporter.NewReporter(os.Stderr)
-	ctx = WithTestReporter(ctx, testReporter)
-	relayerExecReporter := testReporter.RelayerExecReporter(t)
-	ctx = WithRelayerExecReporter(ctx, relayerExecReporter)
-
-	config := &Config{}
-	err := envconfig.Process("TEST", config)
-	if err != nil {
-		return nil, err
-	}
-	ctx = WithConfig(ctx, config)
 
 	// This isn't exactly a concern of the test context, but it's a convenient place to set this. Every test calls this function.
 	if err := setEnvironment(); err != nil {
 		return nil, err
 	}
+
+	logger := zaptest.NewLogger(t)
+	ctx = WithLogger(ctx, logger)
+
+	f, err := interchaintest.CreateLogFile(fmt.Sprintf("%d.json", time.Now().Unix()))
+	require.NoError(t, err)
+	testReporter := testreporter.NewReporter(f)
+	ctx = WithTestReporter(ctx, testReporter)
+	relayerExecReporter := testReporter.RelayerExecReporter(t)
+	ctx = WithRelayerExecReporter(ctx, relayerExecReporter)
+
+	config := &Config{}
+	err = envconfig.Process("TEST", config)
+	if err != nil {
+		return nil, err
+	}
+	ctx = WithConfig(ctx, config)
+
+	dockerClient, dockerNetwork := interchaintest.DockerSetup(t)
+	dockerContext := &dockerContext{
+		NetworkID: dockerNetwork,
+		Client:    dockerClient,
+	}
+	ctx = WithDockerContext(ctx, dockerContext)
 
 	return ctx, nil
 }

--- a/interchaintests/fresh/endpoints.go
+++ b/interchaintests/fresh/endpoints.go
@@ -3,6 +3,7 @@ package fresh
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
 
@@ -92,4 +93,13 @@ func RPCEndpointsTest(ctx context.Context, t *testing.T, chain *cosmos.CosmosCha
 			require.Contains(t, body["result"], tt.key)
 		})
 	}
+}
+
+func CheckEndpoint(ctx context.Context, t *testing.T, url string, f func([]byte) error) {
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	bts, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, f(bts))
 }

--- a/interchaintests/fresh/ica.go
+++ b/interchaintests/fresh/ica.go
@@ -28,7 +28,7 @@ func ICAControllerTest(ctx context.Context, t *testing.T, controller *cosmos.Cos
 	require.NoError(t, err)
 	dstAddress := wallets[0].Address
 
-	srcChannel, err := GetTransferChannel(ctx, controller, relayer)
+	srcChannel, err := GetTransferChannel(ctx, relayer, controller, host)
 	require.NoError(t, err)
 	srcConnection := srcChannel.ConnectionHops[0]
 
@@ -54,7 +54,7 @@ func ICAControllerTest(ctx context.Context, t *testing.T, controller *cosmos.Cos
 	}, ibc.TransferOptions{})
 	require.NoError(t, err)
 
-	require.NoError(t, relayer.Flush(ctx, GetRelayerExecReporter(ctx), RELAYER_PATH_NAME, srcChannel.ChannelID))
+	require.NoError(t, relayer.Flush(ctx, GetRelayerExecReporter(ctx), RelayerTransferPathFor(controller, host), srcChannel.ChannelID))
 
 	balances, err := host.AllBalances(ctx, icaAddress)
 	require.NoError(t, err)
@@ -83,7 +83,7 @@ func ICAControllerTest(ctx context.Context, t *testing.T, controller *cosmos.Cos
 	icaAmount := int64(amountToSend / 3)
 
 	sendICATx(ctx, t, controller, srcAddress, dstAddress, icaAddress, srcConnection, icaAmount, ibcStakeDenom)
-	require.NoError(t, relayer.Flush(ctx, GetRelayerExecReporter(ctx), RELAYER_PATH_NAME, srcChannel.ChannelID))
+	require.NoError(t, relayer.Flush(ctx, GetRelayerExecReporter(ctx), RelayerTransferPathFor(controller, host), srcChannel.ChannelID))
 
 	balances, err = host.AllBalances(ctx, dstAddress)
 	require.NoError(t, err)

--- a/interchaintests/fresh/ics.go
+++ b/interchaintests/fresh/ics.go
@@ -1,0 +1,296 @@
+package fresh
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/types"
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
+	ccvclient "github.com/cosmos/interchain-security/v3/x/ccv/provider/client"
+	"github.com/strangelove-ventures/interchaintest/v7"
+	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v7/ibc"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func isValoperJailed(ctx context.Context, t *testing.T, provider *cosmos.CosmosChain, valoper string) bool {
+	out, _, err := provider.Validators[0].ExecQuery(ctx, "staking", "validator", valoper)
+	require.NoError(t, err)
+	return gjson.GetBytes(out, "jailed").Bool()
+}
+
+func ValidatorJailedTest(ctx context.Context, t *testing.T, provider *cosmos.CosmosChain, consumer *cosmos.CosmosChain, relayer ibc.Relayer) {
+	require.NoError(t, consumer.Validators[1].StopContainer(ctx))
+	require.NoError(t, consumer.Validators[2].StopContainer(ctx))
+
+	wallets, err := GetValidatorWallets(ctx, provider)
+	require.NoError(t, err)
+	valoper2 := wallets[1].ValoperAddress
+	valoper3 := wallets[2].ValoperAddress
+
+	require.Eventually(t, func() bool {
+		return isValoperJailed(ctx, t, provider, valoper2)
+	}, 30*COMMIT_TIMEOUT, COMMIT_TIMEOUT)
+	require.False(t, isValoperJailed(ctx, t, provider, valoper3))
+
+	require.NoError(t, consumer.Validators[1].StartContainer(ctx))
+	provider.Validators[1].ExecTx(ctx, wallets[1].Moniker, "slashing", "unjail")
+	require.False(t, isValoperJailed(ctx, t, provider, valoper2))
+}
+
+func CCVKeyAssignmentTest(ctx context.Context, t *testing.T, provider, consumer *cosmos.CosmosChain, relayer ibc.Relayer) {
+	wallets, err := GetValidatorWallets(ctx, provider)
+	require.NoError(t, err)
+	providerAddress := wallets[0]
+
+	json, err := provider.Validators[0].ReadFile(ctx, "config/priv_validator_key.json")
+	require.NoError(t, err)
+	providerHex := gjson.GetBytes(json, "address").String()
+	json, err = consumer.Validators[0].ReadFile(ctx, "config/priv_validator_key.json")
+	require.NoError(t, err)
+	consumerHex := gjson.GetBytes(json, "address").String()
+
+	var providerPowerBefore int64
+	CheckEndpoint(ctx, t, provider.GetHostRPCAddress()+"/validators", func(b []byte) error {
+		providerPowerBefore = gjson.GetBytes(b, fmt.Sprintf("result.validators.#(address==\"%s\").voting_power", providerHex)).Int()
+		if providerPowerBefore == 0 {
+			return fmt.Errorf("provider validator %s power not found; validators are: %s", providerHex, string(b))
+		}
+		return nil
+	})
+
+	_, err = provider.Validators[0].ExecTx(ctx, providerAddress.Moniker,
+		"staking", "delegate",
+		providerAddress.ValoperAddress, fmt.Sprintf("%d%s", VALIDATOR_STAKE_STEP, DENOM),
+	)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		var providerPower int64
+		CheckEndpoint(ctx, t, provider.GetHostRPCAddress()+"/validators", func(b []byte) error {
+			providerPower = gjson.GetBytes(b, fmt.Sprintf("result.validators.#(address==\"%s\").voting_power", providerHex)).Int()
+			if providerPower == 0 {
+				return fmt.Errorf("provider validator %s power not found; validators are: %s", providerHex, string(b))
+			}
+			return nil
+		})
+
+		var consumerPower int64
+		CheckEndpoint(ctx, t, consumer.GetHostRPCAddress()+"/validators", func(b []byte) error {
+			consumerPower = gjson.GetBytes(b, fmt.Sprintf("result.validators.#(address==\"%s\").voting_power", consumerHex)).Int()
+			if consumerPower == 0 {
+				return fmt.Errorf("consumer validator %s power not found; validators are: %s", consumerHex, string(b))
+			}
+			return nil
+		})
+		if providerPowerBefore >= providerPower {
+			return false
+		}
+		return providerPower == consumerPower
+	}, 10*time.Minute, COMMIT_TIMEOUT)
+}
+
+func AddConsumerChain(ctx context.Context, t *testing.T, provider *cosmos.CosmosChain, relayer ibc.Relayer, chainName, version, denom string, shouldCopyProviderKey []bool) *cosmos.CosmosChain {
+	dockerClient, dockerNetwork := GetDockerContext(ctx)
+
+	if len(shouldCopyProviderKey) != NUM_VALIDATORS {
+		panic(fmt.Sprintf("shouldCopyProviderKey must be the same length as the number of validators (%d)", NUM_VALIDATORS))
+	}
+
+	chainID := fmt.Sprintf("%s-%d", chainName, len(provider.Consumers)+1)
+	cf := interchaintest.NewBuiltinChainFactory(
+		GetLogger(ctx),
+		[]*interchaintest.ChainSpec{createConsumerChainSpec(ctx, chainID, chainName, denom, version, shouldCopyProviderKey)},
+	)
+	chains, err := cf.Chains(t.Name())
+	require.NoError(t, err)
+	consumer := chains[0].(*cosmos.CosmosChain)
+
+	// We can't use AddProviderConsumerLink here because the provider chain is already built; we'll have to do everything by hand.
+	provider.Consumers = append(provider.Consumers, consumer)
+	consumer.Provider = provider
+
+	consumerAdditionProposal(ctx, t, chainID, provider)
+
+	wallet, err := consumer.BuildRelayerWallet(ctx, "relayer-"+consumer.Config().ChainID)
+	require.NoError(t, err)
+	ic := interchaintest.NewInterchain().
+		AddChain(consumer, ibc.WalletAmount{
+			Address: wallet.FormattedAddress(),
+			Denom:   consumer.Config().Denom,
+			Amount:  sdkmath.NewInt(VALIDATOR_FUNDS),
+		}).
+		AddRelayer(relayer, "relayer")
+
+	require.NoError(t, ic.Build(ctx, GetRelayerExecReporter(ctx), interchaintest.InterchainBuildOptions{
+		Client:    dockerClient,
+		NetworkID: dockerNetwork,
+		TestName:  t.Name(),
+	}))
+	t.Cleanup(func() {
+		_ = ic.Close()
+	})
+
+	setupRelayerKeys(ctx, t, relayer, wallet, consumer)
+	connectChains(ctx, t, provider, consumer, relayer)
+
+	return consumer
+}
+
+func createConsumerChainSpec(ctx context.Context, chainID, chainType, denom, version string, shouldCopyProviderKey []bool) *interchaintest.ChainSpec {
+	fullNodes := 0
+	validators := 3
+
+	bechPrefix := ""
+	if chainType == "ics-consumer" {
+		majorVersion, err := strconv.Atoi(version[1:2])
+		if err != nil {
+			// this really shouldn't happen unless someone misconfigured something
+			panic(fmt.Sprintf("failed to parse major version from %s: %v", version, err))
+		}
+		if majorVersion >= 4 {
+			bechPrefix = "consumer"
+		}
+	} else if chainType == "stride" {
+		bechPrefix = "stride"
+	}
+	genesisOverrides := []cosmos.GenesisKV{
+		cosmos.NewGenesisKV("app_state.slashing.params.signed_blocks_window", strconv.Itoa(SLASHING_WINDOW_CONSUMER)),
+	}
+
+	return &interchaintest.ChainSpec{
+		Name:          chainType,
+		Version:       version,
+		ChainName:     chainID,
+		NumFullNodes:  &fullNodes,
+		NumValidators: &validators,
+		ChainConfig: ibc.ChainConfig{
+			Denom:         denom,
+			GasPrices:     "0.005" + denom,
+			ChainID:       chainID,
+			GasAdjustment: 2.0,
+			ConfigFileOverrides: map[string]any{
+				"config/config.toml": createConfigToml(),
+			},
+			Bech32Prefix: bechPrefix,
+			ModifyGenesisAmounts: func(i int) (types.Coin, types.Coin) {
+				return types.Coin{
+						Amount: sdkmath.NewInt(VALIDATOR_FUNDS),
+						Denom:  denom,
+					}, types.Coin{
+						Amount: sdkmath.NewInt(getValidatorStake()[i]),
+						Denom:  denom,
+					}
+			},
+			ModifyGenesis: cosmos.ModifyGenesis(genesisOverrides),
+			ConsumerCopyProviderKey: func(i int) bool {
+				return shouldCopyProviderKey[i]
+			},
+		},
+	}
+}
+
+func setupRelayerKeys(ctx context.Context, t *testing.T, relayer ibc.Relayer, wallet ibc.Wallet, chain *cosmos.CosmosChain) error {
+	rep := GetRelayerExecReporter(ctx)
+	rpcAddr, grpcAddr := chain.GetRPCAddress(), chain.GetGRPCAddress()
+	if !relayer.UseDockerNetwork() {
+		rpcAddr, grpcAddr = chain.GetHostRPCAddress(), chain.GetHostGRPCAddress()
+	}
+
+	chainName := chain.Config().ChainID
+	require.NoError(t, relayer.AddChainConfiguration(ctx,
+		rep,
+		chain.Config(), chainName,
+		rpcAddr, grpcAddr,
+	))
+
+	require.NoError(t, relayer.RestoreKey(ctx,
+		rep,
+		chain.Config(), chainName,
+		wallet.Mnemonic(),
+	))
+
+	return nil
+}
+
+func connectChains(ctx context.Context, t *testing.T, provider *cosmos.CosmosChain, consumer *cosmos.CosmosChain, relayer ibc.Relayer) {
+	icsPath := RelayerICSPathFor(provider, consumer)
+	rep := GetRelayerExecReporter(ctx)
+	require.NoError(t, relayer.GeneratePath(ctx, rep, consumer.Config().ChainID, provider.Config().ChainID, icsPath))
+
+	consumerClients, err := relayer.GetClients(ctx, rep, consumer.Config().ChainID)
+	require.NoError(t, err)
+
+	var consumerClient *ibc.ClientOutput
+	for _, client := range consumerClients {
+		if client.ClientState.ChainID == provider.Config().ChainID {
+			consumerClient = client
+			break
+		}
+	}
+	require.NotNilf(t, consumerClient, "consumer chain %s does not have a client tracking the provider chain %s", consumer.Config().ChainID, provider.Config().ChainID)
+	consumerClientID := consumerClient.ClientID
+
+	providerClients, err := relayer.GetClients(ctx, rep, provider.Config().ChainID)
+	require.NoError(t, err)
+
+	var providerClient *ibc.ClientOutput
+	for _, client := range providerClients {
+		if client.ClientState.ChainID == consumer.Config().ChainID {
+			providerClient = client
+			break
+		}
+	}
+	require.NotNilf(t, providerClient, "provider chain %s does not have a client tracking the consumer chain %s for path %s on relayer %s",
+		provider.Config().ChainID, consumer.Config().ChainID, icsPath, relayer)
+	providerClientID := providerClient.ClientID
+
+	require.NoError(t, relayer.UpdatePath(ctx, rep, icsPath, ibc.PathUpdateOptions{
+		SrcClientID: &consumerClientID,
+		DstClientID: &providerClientID,
+	}))
+
+	require.NoError(t, relayer.CreateConnections(ctx, rep, icsPath))
+
+	require.NoError(t, relayer.CreateChannel(ctx, rep, icsPath, ibc.CreateChannelOptions{
+		SourcePortName: "consumer",
+		DestPortName:   "provider",
+		Order:          ibc.Ordered,
+		Version:        "1",
+	}))
+
+	require.NoError(t, relayer.StopRelayer(ctx, rep))
+	require.NoError(t, relayer.StartRelayer(ctx, rep))
+	require.Eventually(t, func() bool {
+		providerTxChannel, err := GetTransferChannel(ctx, relayer, provider, consumer)
+		return err == nil && providerTxChannel != nil
+	}, 2*time.Minute, 10*time.Second)
+}
+
+func consumerAdditionProposal(ctx context.Context, t *testing.T, chainID string, provider *cosmos.CosmosChain) {
+	prop := ccvclient.ConsumerAdditionProposalJSON{
+		Title:         fmt.Sprintf("Addition of %s consumer chain", chainID),
+		Summary:       "Proposal to add new consumer chain",
+		ChainId:       chainID,
+		InitialHeight: clienttypes.Height{RevisionNumber: clienttypes.ParseChainID(chainID), RevisionHeight: 1},
+		GenesisHash:   []byte("gen_hash"),
+		BinaryHash:    []byte("bin_hash"),
+		SpawnTime:     time.Now(),
+
+		BlocksPerDistributionTransmission: 1000,
+		CcvTimeoutPeriod:                  2419200000000000,
+		TransferTimeoutPeriod:             3600000000000,
+		ConsumerRedistributionFraction:    "0.75",
+		HistoricalEntries:                 10000,
+		UnbondingPeriod:                   1728000000000000,
+		Deposit:                           GOV_DEPOSIT_AMOUNT,
+	}
+	propTx, err := provider.ConsumerAdditionProposal(ctx, VALIDATOR_MONIKER, prop)
+	require.NoError(t, err)
+	PassProposal(ctx, t, provider, propTx.ProposalID)
+}

--- a/interchaintests/fresh/transactions.go
+++ b/interchaintests/fresh/transactions.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"cosmossdk.io/math"
+	transfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
+	"github.com/strangelove-ventures/interchaintest/v7/ibc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,4 +59,48 @@ func TransactionsTest(ctx context.Context, t *testing.T, chain *cosmos.CosmosCha
 		)
 		require.NoError(t, err)
 	})
+}
+
+func IBCTest(ctx context.Context, t *testing.T, chainA *cosmos.CosmosChain, chainB *cosmos.CosmosChain, relayer ibc.Relayer) {
+	wallets, err := GetValidatorWallets(ctx, chainA)
+	require.NoError(t, err)
+	wallet1 := wallets[0]
+
+	wallets, err = GetValidatorWallets(ctx, chainB)
+	require.NoError(t, err)
+	wallet2 := wallets[0]
+	addr1 := wallet1.Address
+	addr2 := wallet2.Address
+
+	senderTxChannel, err := GetTransferChannel(ctx, relayer, chainA, chainB)
+	require.NoError(t, err)
+
+	srcDenomTrace := transfertypes.ParseDenomTrace(transfertypes.GetPrefixedDenom("transfer", senderTxChannel.Counterparty.ChannelID, chainA.Config().Denom))
+	dstIbcDenom := srcDenomTrace.IBCDenom()
+
+	initial1, err := chainA.GetBalance(ctx, addr1, chainA.Config().Denom)
+	require.NoError(t, err)
+	initial2, err := chainB.GetBalance(ctx, addr2, dstIbcDenom)
+	require.NoError(t, err)
+
+	amountToSend := math.NewInt(1_000_000)
+	_, err = chainA.Validators[0].SendIBCTransfer(ctx, senderTxChannel.ChannelID, wallet1.Moniker, ibc.WalletAmount{
+		Denom:   chainA.Config().Denom,
+		Amount:  amountToSend,
+		Address: addr2,
+	}, ibc.TransferOptions{})
+	require.NoError(t, err)
+
+	res := relayer.Exec(ctx, GetRelayerExecReporter(ctx), []string{
+		"hermes", "clear", "packets", "--chain", chainA.Config().ChainID, "--channel", senderTxChannel.ChannelID, "--port", "transfer",
+	}, nil)
+	require.NoError(t, res.Err)
+
+	final1, err := chainA.GetBalance(ctx, addr1, chainA.Config().Denom)
+	require.NoError(t, err)
+	final2, err := chainB.GetBalance(ctx, addr2, dstIbcDenom)
+	require.NoError(t, err)
+
+	require.Equal(t, initial2.Add(amountToSend), final2)
+	require.True(t, final1.LTE(initial1.Sub(amountToSend)), "final1: %s, initial1 - amountToSend: %s", final1, initial1.Sub(amountToSend))
 }

--- a/interchaintests/fresh/v16_ibc_rate_limiting_test.go
+++ b/interchaintests/fresh/v16_ibc_rate_limiting_test.go
@@ -12,7 +12,7 @@ func TestV16UpgradeIBCRateLimiting(t *testing.T) {
 	require.NoError(t, err)
 
 	chainA, chainB, relayer := fresh.CreateLinkedChains(ctx, t, fresh.GetConfig(ctx).StartVersion)
-	channel, err := fresh.GetTransferChannel(ctx, chainA, relayer)
+	channel, err := fresh.GetTransferChannel(ctx, relayer, chainA, chainB)
 	require.NoError(t, err)
 
 	fresh.UpgradeChain(ctx, t, chainA, fresh.VALIDATOR_MONIKER, fresh.GetConfig(ctx).TargetVersion, fresh.GetConfig(ctx).UpgradeVersion)

--- a/interchaintests/go.mod
+++ b/interchaintests/go.mod
@@ -6,18 +6,22 @@ replace (
 	github.com/ChainSafe/go-schnorrkel => github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d
 	github.com/ChainSafe/go-schnorrkel/1 => github.com/ChainSafe/go-schnorrkel v1.0.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/strangelove-ventures/interchaintest/v7 => github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240326150917-3667d1967030
+	github.com/strangelove-ventures/interchaintest/v7 => github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240405165823-4731b92e5442
 	github.com/vedhavyas/go-subkey => github.com/strangelove-ventures/go-subkey v1.0.7
 )
 
 require (
 	cosmossdk.io/math v1.1.2
+	github.com/cometbft/cometbft v0.37.2
 	github.com/cosmos/cosmos-sdk v0.47.5
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v7 v7.3.0
+	github.com/cosmos/interchain-security/v3 v3.1.1-0.20231102122221-81650a84f989
+	github.com/docker/docker v24.0.7+incompatible
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/strangelove-ventures/interchaintest/v7 v7.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.8.4
+	github.com/tidwall/gjson v1.17.1
 	go.uber.org/zap v1.26.0
 	golang.org/x/sync v0.4.0
 )
@@ -60,7 +64,6 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/coinbase/rosetta-sdk-go/types v1.0.0 // indirect
-	github.com/cometbft/cometbft v0.37.2 // indirect
 	github.com/cometbft/cometbft-db v0.8.0 // indirect
 	github.com/confio/ics23/go v0.9.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
@@ -70,7 +73,6 @@ require (
 	github.com/cosmos/iavl v0.20.0 // indirect
 	github.com/cosmos/ibc-go/modules/capability v1.0.0-rc1 // indirect
 	github.com/cosmos/ics23/go v0.10.0 // indirect
-	github.com/cosmos/interchain-security/v3 v3.1.1-0.20231102122221-81650a84f989 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.13.0 // indirect
 	github.com/cosmos/rosetta-sdk-go v0.10.0 // indirect
 	github.com/creachadair/taskgroup v0.4.2 // indirect
@@ -86,7 +88,6 @@ require (
 	github.com/dgraph-io/ristretto v0.1.1 // indirect
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
-	github.com/docker/docker v24.0.7+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -197,6 +198,8 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect
 	github.com/tidwall/btree v1.6.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tyler-smith/go-bip32 v1.0.0 // indirect
 	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/ulikunitz/xz v0.5.11 // indirect

--- a/interchaintests/go.sum
+++ b/interchaintests/go.sum
@@ -712,8 +712,8 @@ github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0Jr
 github.com/huandu/skiplist v1.2.0 h1:gox56QD77HzSC0w+Ws3MH3iie755GBJU1OER3h5VsYw=
 github.com/huandu/skiplist v1.2.0/go.mod h1:7v3iFjLcSAzO4fN5B8dvebvo/qsfumiLiDXMrPiHF9w=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240326150917-3667d1967030 h1:T/ztaIvS7ynU5HoJ1VxwD1go161n/LQPpUsPPudMSEQ=
-github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240326150917-3667d1967030/go.mod h1:PPk5NJujtwQuh4zbVO0MUnZk7WBMe6eJZfoegx+Z/dc=
+github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240405165823-4731b92e5442 h1:8BajgCNUbBtAX1rJEcu0ksVHyaWgkotg8JC99soKJSU=
+github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240405165823-4731b92e5442/go.mod h1:PXx8W5iPcYeBYZAlwAZ/2Hw5x5B/PKbMzbdvWAAZcSM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845 h1:H+uM0Bv88eur3ZSsd2NGKg3YIiuXxwxtlN7HjE66UTU=
@@ -1071,6 +1071,13 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=
 github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
+github.com/tidwall/gjson v1.17.1 h1:wlYEnwqAHgzmhNUFfw7Xalt2JzQvsMx2Se4PcoFCT/U=
+github.com/tidwall/gjson v1.17.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tklauser/go-sysconf v0.3.11 h1:89WgdJhk5SNwJfu+GKyYveZ4IaJ7xAkecBo+KdJV0CM=
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
 github.com/tklauser/numcpus v0.4.0 h1:E53Dm1HjH1/R2/aoCtXtPgzmElmn51aOkhCFSuZq//o=


### PR DESCRIPTION
Includes tests for ics versions 3.3 and 4; also has the code for a test with neutron and stride, but neutron isn't launching yet, so I disabled the test.

The ICS tests work by launching a consumer chain, upgrading the provider, checking that the consumer still works (i.e. stake delegations from the provider are reflected in the consumer, and IBC transfers work) then launching a new consumer chain and checking that _it_ works.