### PR TITLE
Enable stride + neutron tests, fix blocks per epoch.

### DIFF
--- a/interchaintests/configuredChains.yaml
+++ b/interchaintests/configuredChains.yaml
@@ -18,8 +18,8 @@ stride:
   bin: strided
   bech32-prefix: stride
   denom: ustrd
-  gas-prices: 0.01ustrd
-  gas-adjustment: 1.3
+  gas-prices: 0.005ustrd
+  gas-adjustment: 2.0
   trusting-period: "336h"
   images:
     - repository: ghcr.io/strangelove-ventures/heighliner/stride
@@ -32,8 +32,8 @@ neutron:
   bin: neutrond
   bech32-prefix: neutron
   denom: untrn
-  gas-prices: 0.01untrn
-  gas-adjustment: 1.3
+  gas-prices: 0.005untrn
+  gas-adjustment: 2.0
   trusting-period: "336h"
   images:
     - repository: ghcr.io/strangelove-ventures/heighliner/neutron

--- a/interchaintests/fresh/baseline_consumer_chains_test.go
+++ b/interchaintests/fresh/baseline_consumer_chains_test.go
@@ -21,6 +21,7 @@ func runConsumerChainTest(t *testing.T, otherChain, otherChainVersion string, sh
 
 	require.NoError(t, relayer.StopRelayer(ctx, fresh.GetRelayerExecReporter(ctx)))
 	require.NoError(t, relayer.StartRelayer(ctx, fresh.GetRelayerExecReporter(ctx)))
+	fresh.SetEpoch(ctx, t, provider, 1)
 	fresh.CCVKeyAssignmentTest(ctx, t, provider, consumer, relayer)
 	fresh.IBCTest(ctx, t, provider, consumer, relayer)
 
@@ -47,15 +48,14 @@ func TestConsumerChainLaunchesAfterV16UpgradeICS33NoKeysCopied(t *testing.T) {
 }
 
 func TestMainnetConsumerChainsWithV16Upgrade(t *testing.T) {
-	t.Skip("This test is failing because neutron isn't launching")
 	ctx, err := fresh.NewTestContext(t)
 	require.NoError(t, err)
 	const neutronVersion = "v3.0.1"
 	const strideVersion = "v20.0.0"
 
 	provider, relayer := fresh.CreateChain(ctx, t, fresh.GetConfig(ctx).StartVersion, true)
-	stride := fresh.AddConsumerChain(ctx, t, provider, relayer, "stride", strideVersion, fresh.STRIDE_DENOM, []bool{true, true, true})
 	neutron := fresh.AddConsumerChain(ctx, t, provider, relayer, "neutron", neutronVersion, fresh.NEUTRON_DENOM, []bool{true, true, true})
+	stride := fresh.AddConsumerChain(ctx, t, provider, relayer, "stride", strideVersion, fresh.STRIDE_DENOM, []bool{true, true, true})
 
 	fresh.CCVKeyAssignmentTest(ctx, t, provider, neutron, relayer)
 	fresh.IBCTest(ctx, t, provider, neutron, relayer)
@@ -66,6 +66,7 @@ func TestMainnetConsumerChainsWithV16Upgrade(t *testing.T) {
 
 	require.NoError(t, relayer.StopRelayer(ctx, fresh.GetRelayerExecReporter(ctx)))
 	require.NoError(t, relayer.StartRelayer(ctx, fresh.GetRelayerExecReporter(ctx)))
+	fresh.SetEpoch(ctx, t, provider, 1)
 
 	fresh.CCVKeyAssignmentTest(ctx, t, provider, neutron, relayer)
 	fresh.IBCTest(ctx, t, provider, neutron, relayer)

--- a/interchaintests/fresh/chains.go
+++ b/interchaintests/fresh/chains.go
@@ -12,6 +12,7 @@ import (
 	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/types"
 	govv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	"github.com/cosmos/cosmos-sdk/x/params/client/utils"
 	"github.com/strangelove-ventures/interchaintest/v7"
 	"github.com/strangelove-ventures/interchaintest/v7/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v7/ibc"
@@ -324,4 +325,19 @@ func GetValidatorWallets(ctx context.Context, chain *cosmos.CosmosChain) ([]Vali
 		return nil, err
 	}
 	return wallets, nil
+}
+
+func SetEpoch(ctx context.Context, t *testing.T, chain *cosmos.CosmosChain, epoch int) {
+	result, err := chain.ParamChangeProposal(ctx, VALIDATOR_MONIKER, &utils.ParamChangeProposalJSON{
+		Changes: []utils.ParamChangeJSON{{
+			Subspace: "provider",
+			Key:      "BlocksPerEpoch",
+			Value:    json.RawMessage(fmt.Sprintf("\"%d\"", epoch)),
+		}},
+		Title:       fmt.Sprintf("Set blocks per epoch to %d", epoch),
+		Description: fmt.Sprintf("Set blocks per epoch to %d", epoch),
+		Deposit:     GOV_DEPOSIT_AMOUNT,
+	})
+	require.NoError(t, err)
+	PassProposal(ctx, t, chain, result.ProposalID)
 }

--- a/interchaintests/fresh/ics.go
+++ b/interchaintests/fresh/ics.go
@@ -161,6 +161,17 @@ func createConsumerChainSpec(ctx context.Context, chainID, chainType, denom, ver
 	}
 	genesisOverrides := []cosmos.GenesisKV{
 		cosmos.NewGenesisKV("app_state.slashing.params.signed_blocks_window", strconv.Itoa(SLASHING_WINDOW_CONSUMER)),
+		cosmos.NewGenesisKV("consensus_params.block.max_gas", "50000000"),
+	}
+	if chainType == "neutron" {
+		genesisOverrides = append(genesisOverrides,
+			cosmos.NewGenesisKV("app_state.globalfee.params.minimum_gas_prices", []interface{}{
+				map[string]interface{}{
+					"amount": "0.005",
+					"denom":  denom,
+				},
+			}),
+		)
 	}
 
 	return &interchaintest.ChainSpec{

--- a/interchaintests/go.mod
+++ b/interchaintests/go.mod
@@ -6,7 +6,7 @@ replace (
 	github.com/ChainSafe/go-schnorrkel => github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d
 	github.com/ChainSafe/go-schnorrkel/1 => github.com/ChainSafe/go-schnorrkel v1.0.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/strangelove-ventures/interchaintest/v7 => github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240405165823-4731b92e5442
+	github.com/strangelove-ventures/interchaintest/v7 => github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240409184851-0afb5d2d6764
 	github.com/vedhavyas/go-subkey => github.com/strangelove-ventures/go-subkey v1.0.7
 )
 

--- a/interchaintests/go.sum
+++ b/interchaintests/go.sum
@@ -712,8 +712,8 @@ github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0Jr
 github.com/huandu/skiplist v1.2.0 h1:gox56QD77HzSC0w+Ws3MH3iie755GBJU1OER3h5VsYw=
 github.com/huandu/skiplist v1.2.0/go.mod h1:7v3iFjLcSAzO4fN5B8dvebvo/qsfumiLiDXMrPiHF9w=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240405165823-4731b92e5442 h1:8BajgCNUbBtAX1rJEcu0ksVHyaWgkotg8JC99soKJSU=
-github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240405165823-4731b92e5442/go.mod h1:PXx8W5iPcYeBYZAlwAZ/2Hw5x5B/PKbMzbdvWAAZcSM=
+github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240409184851-0afb5d2d6764 h1:A7fcj6dC+zLQVKENtuiREm4IEdPgVjeJShfdiuxgppI=
+github.com/hyphacoop/interchaintest/v7 v7.0.1-0.20240409184851-0afb5d2d6764/go.mod h1:PXx8W5iPcYeBYZAlwAZ/2Hw5x5B/PKbMzbdvWAAZcSM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/icza/dyno v0.0.0-20220812133438-f0b6f8a18845 h1:H+uM0Bv88eur3ZSsd2NGKg3YIiuXxwxtlN7HjE66UTU=


### PR DESCRIPTION
Neutron & Stride tests just ensure that the chains are still running after the v16 upgrade.
Also, I set BlocksPerEpoch to 1 everywhere for now.